### PR TITLE
Updating copy now that fund is endowed.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,22 +16,6 @@
   <script src="/js/site.js"></script>
 </head>
 <body>
-  <div class="topbar hidden-xs hidden-sm">
-    <div class="container">
-      <div class="row">
-        <div class="col-md-6">
-          <p><strong>Progress towards $125,000 to endow the fund</strong></p>
-        </div>
-        <div class="col-md-6">
-          <div class="progress">
-            <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="min-width:4em;width: 100%;">
-              $128,227
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
   <nav class="navbar navbar-default navbar-fixed-top hidden-md hidden-lg">
     <div class="container-fluid">
       <div class="navbar-header">

--- a/index.html
+++ b/index.html
@@ -16,15 +16,13 @@ layout: default
   <h4 id="how">How</h4>
   <p>We've signed a <a href="/agreement">Memorandum of Understanding</a> with Olin, which spells out the details. Here are the basics:</p>
   <ul>
-    <li>We must create an endowment of <strong>$125,000</strong> by <strong>June 30, 2018</strong>.</li>
     <li>Once endowed, the fund will distribute a scholarship from the endowment’s earnings (in accordance with the college's policies) such that each student in their eighth semester would receive an equal scholarship. These distributions will start small, with a minimum of $75 distributed per student. </li>
     <li>In future years, once the distribution exceeds the cost of the eighth semester's tuition, the Fund would then start distributing money to the preceding semesters (seventh semester, followed by sixth, etc.) until the entire four year tuition of each student is covered.</li>
     <li>If any distribution would fall below <strong>$75</strong> in a year, no distribution would be made.</li>
-    <li>If we fail to raise $125,000 by June 30, 2018, all collected funds will be marked unrestricted and the fund will dissolve.</li>
   </ul>
 
   <h4 id="progress">Progress</h4>
-  <p>We'll periodically update our progress towards the $125,000 goal below.</p>
+  <p>We'll periodically update our progress below.</p>
   <ul>
     <li><em>March 26, 2015 (initial announcement)</em> - <strong>$846.82</strong></li>
     <li><em>May 5, 2015</em> - <strong>$9,900</strong></li>


### PR DESCRIPTION
Now that the fund is endowed, the details of the endowment process are superfluous. Removing these details removes any ambiguity around if the fund reached endowment. The details are still present in the full Memorandum of Understanding.
