### PR TITLE
Update AMSF data with FY 2022-2024 distributions and progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@ layout: default
     <li><em>FY 2016</em> - <strong>$75</strong> was awarded to <strong>64</strong> students. $4,800 funded by the college in support of the endeavor.</li>
     <li><em>FY 2017</em> - <strong>$75</strong> was awarded to <strong>68</strong> students. $5,100 funded by the college; the endowment was negative.</li>
     <li><em>FY 2018</em> - <strong>$75</strong> was awarded to <strong>77</strong> students. $5,775 funded by the endowed fund.</li>
+    <li><em>FY 2022</em> - <strong>$250</strong> was awarded to <strong>53</strong> students. Total award expenses: $13,250.</li>
+    <li><em>FY 2023</em> - <strong>$250</strong> was awarded to <strong>76</strong> students. Total award expenses: $19,000.</li>
+    <li><em>FY 2024</em> - <strong>$300</strong> was awarded to <strong>91</strong> students. Total award expenses: $27,300.</li>
   </ul>
 
   <h4 id="progress">Progress</h4>
@@ -58,6 +61,9 @@ layout: default
     <li><em>Jun 30, 2019</em> - Principal: <strong>$513,269</strong>, Market Value: $580,563</li>
     <li><em>Dec 31, 2019</em> - Principal: <strong>?</strong>, Market Value: $678,000</li>
     <li><em>Nov 30, 2021</em> - Principal: <strong>$751,758.09</strong>, Market Value: $1,070,826.34</li>
+    <li><em>Jun 30, 2022</em> - Principal: <strong>$815,533</strong>, Accumulated Earnings: $251,997, Market Value: $1,054,280</li>
+    <li><em>Jun 30, 2023</em> - Principal: <strong>$884,434</strong>, Accumulated Earnings: $284,088, Market Value: $1,149,522</li>
+    <li><em>Jun 30, 2024</em> - Principal: <strong>$937,251</strong>, Accumulated Earnings: $380,954, Market Value: $1,290,905</li>
   </ul>
 
   <h4 id="financial-model">Financial Model</h4>


### PR DESCRIPTION
## Summary
Updates the Alumni Merit Scholarship Fund (AMSF) data on the website with the latest information through June 30, 2024.

## Changes
- **Distributions section**: Added FY 2022-2024 distribution data showing:
  - FY 2022: $250 awarded to 53 students ($13,250 total)
  - FY 2023: $250 awarded to 76 students ($19,000 total)
  - FY 2024: $300 awarded to 91 students ($27,300 total)

- **Progress section**: Added fund value updates through June 30, 2024:
  - Jun 30, 2022: Market Value $1,054,280 (Principal: $815,533)
  - Jun 30, 2023: Market Value $1,149,522 (Principal: $884,434)
  - Jun 30, 2024: Market Value $1,290,905 (Principal: $937,251)

## Test plan
- [ ] Verify the new distribution entries display correctly
- [ ] Verify the new progress entries display correctly
- [ ] Check that the page still renders properly
- [ ] Confirm all numbers match the source data

🤖 Generated with [Claude Code](https://claude.com/claude-code)